### PR TITLE
added support for 64 bit trace IDs

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,6 +36,7 @@ members = [
     "examples/jaeger-remote-sampler",
     "examples/zipkin",
     "examples/multiple-span-processors",
-    "examples/zpages"
+    "examples/zpages",
+    "examples/backward-compatibility",
 ]
 exclude = ["examples/external-otlp-grpcio-async-std"]

--- a/examples/README.md
+++ b/examples/README.md
@@ -212,6 +212,15 @@ This example uses following crates from this repo:
 - opentelemetry(tracing)
 - opentelemetry-zpages
 
+## backward-compatibility
+**Tracing**
+
+This example uses following crates from this repo:
+- opentelemetry
+- opentelemetry-sdk
+- opentelemetry-otlp
+- opentelemetry-semantic-conventions
+
 The application is built using `tokio` and `hyper`.
 
 Check this example if you want to understand *how to set up a zpage server to debug tracing issues*.

--- a/examples/backward-compatibility/Cargo.toml
+++ b/examples/backward-compatibility/Cargo.toml
@@ -1,0 +1,21 @@
+[package]
+name = "backward-compatibility"
+version = "0.1.0"
+edition = "2021"
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]
+reqwest = { version = "0.11", features = ["json"] } # reqwest with JSON parsing support
+futures = "0.3" # for our async / await blocks
+tokio = { version = "1.12.0", features = ["full"] } # for our async runtime
+serde = { version = "1.0", features = ["derive"] }
+serde_json = "1.0"
+opentelemetry-http = { version =  "0.6.0" }
+hyper = "0.14.26"
+rand = "0.8.5"
+
+opentelemetry = { path = "../../opentelemetry", features =  ["rt-tokio", "trace"] }
+opentelemetry_sdk = { path = "../../opentelemetry-sdk" }
+opentelemetry-otlp = { path = "../../opentelemetry-otlp" }
+opentelemetry-semantic-conventions = { path = "../../opentelemetry-semantic-conventions" }

--- a/examples/backward-compatibility/README.md
+++ b/examples/backward-compatibility/README.md
@@ -1,0 +1,24 @@
+# Backward Compatibility -  Example
+
+This example shows how to create an opentelemetry pipeline to send traces to the receiver that requires TraceID to be in 64-bit format.
+Setting the **with_backward_compatible** flag to true in the Trace config will generate a 128-bit TraceID with high 64-bits set to Zeros. For example, `0000000000000000830f23b7f0bf5f84`.
+The receiver that requires 64-bit TraceID will only pick the low 64-bits by default.
+
+The default value of **with_backward_compatible** flag is false and not setting this or setting it to false will generate 128-bit TraceID. For example, `62a7aade3f9ce7174c6b2c859398d856`.
+
+## Usage
+
+First make sure you have a running version of the opentelemetry collector you want to send data to:
+
+```shell
+$ docker run -p 4317:4317 otel/opentelemetry-collector-dev:latest
+```
+
+```shell
+$ cargo run
+
+Tracer created with ID: 0000000000000000830f23b7f0bf5f84
+```
+
+
+

--- a/examples/backward-compatibility/src/main.rs
+++ b/examples/backward-compatibility/src/main.rs
@@ -1,0 +1,154 @@
+use std::io::{BufRead, BufReader, Read};
+use opentelemetry::{
+    global,
+    sdk::{propagation::TraceContextPropagator, trace as sdktrace, Resource},
+    trace::{Span, TraceContextExt, TraceError, Tracer, SpanId, TraceId},
+    Context, Key, KeyValue
+};
+use opentelemetry_otlp::{WithExportConfig};
+use opentelemetry_semantic_conventions as semcov;
+use std::{thread, time::Duration};
+use reqwest;
+use hyper::Client;
+
+async fn outgoing_request(
+    c_span_id: SpanId, p_span_id: SpanId, trace_id: TraceId
+) -> std::result::Result<(), Box<dyn std::error::Error + Send + Sync + 'static>> {
+
+    let client_2 = reqwest::Client::builder().http1_title_case_headers()
+        .build()?;
+
+    let b3_header = format!("{0}-{1}-{2}-{3}", trace_id,c_span_id, "0",p_span_id);
+
+    let _res = client_2
+        .get("http://localhost:8000/api/test")
+        .header("B3", b3_header)
+        .send()
+        .await?
+        .text()
+        .await?;
+
+    println!("{}", "API Called using b3 single header");
+    Ok(())
+}
+
+async fn outgoing_request_multi(
+    c_span_id: SpanId, p_span_id: SpanId, trace_id: TraceId
+) -> std::result::Result<(), Box<dyn std::error::Error + Send + Sync + 'static>> {
+    let client = Client::new();
+    
+    let req = hyper::Request::builder()
+        .method(hyper::Method::GET)
+        .uri("http://localhost:8000/api/test")
+        .header("X-B3-TraceId", trace_id.to_string())
+        .header("X-B3-SpanId", c_span_id.to_string())
+        .header("X-B3-ParentSpanId", p_span_id.to_string())
+        .body(hyper::Body::empty()).unwrap();
+
+    let resp = client.request(req).await?;
+    let body_bytes = hyper::body::to_bytes(resp.into_body()).await?;
+    let _body = String::from_utf8(body_bytes.to_vec()).unwrap();
+
+    println!("{}", "API Called using b3 multi header");
+    Ok(())
+}
+
+fn read_dt_metadata() -> Resource {
+    fn read_single(path: &str, metadata: &mut Vec<KeyValue>) -> std::io::Result<()> {
+        let mut file = std::fs::File::open(path)?;
+        if path.starts_with("dt_metadata") {
+            let mut name = String::new();
+            file.read_to_string(&mut name)?;
+
+            file = std::fs::File::open(name)?;
+        }
+
+        for line in BufReader::new(file).lines() {
+            if let Some((k, v)) = line?.split_once('=') {
+                metadata.push(KeyValue::new(k.to_string(), v.to_string()))
+            }
+        }
+
+        Ok(())
+    }
+
+    let mut metadata = Vec::new();
+    for name in [
+        "metadata 1",
+        "metadata 2",
+    ] {
+        let _ = read_single(name, &mut metadata);
+    }
+
+    Resource::new(metadata)
+}
+
+
+fn init_tracer() -> Result<sdktrace::Tracer, TraceError> {
+    global::set_text_map_propagator(TraceContextPropagator::new());
+
+    let mut resource = Resource::new(vec![
+        semcov::resource::SERVICE_NAME.string("fdse-1730-service-rust"),
+        semcov::resource::DEPLOYMENT_ENVIRONMENT.string("fdse-1730-env"),
+        semcov::resource::SERVICE_VERSION.string("1.0.1"), 
+    ]);
+
+    resource = resource.merge(&read_dt_metadata());
+
+    opentelemetry_otlp::new_pipeline()
+        .tracing()
+        .with_exporter(
+            opentelemetry_otlp::new_exporter()
+                .tonic()
+                .with_endpoint("http://localhost:4317"),
+        )
+        .with_trace_config(
+            sdktrace::config()
+                .with_resource(resource)
+                .with_sampler(sdktrace::Sampler::AlwaysOn)
+                .with_backward_compatible(true)
+        )
+        .install_simple()
+}
+
+#[tokio::main]
+pub async fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
+    let tracer = init_tracer()?;
+    let m_span = tracer.start("Main Span");
+    let main_cx = Context::current_with_span(m_span);
+    let mut span = tracer.start_with_context("operation waiting", &main_cx);
+    span.set_attribute(KeyValue::new("sample_key", "sample_value")); 
+    thread::sleep(Duration::from_millis(5000));
+    span.add_event(
+        "Waited 5 sec before call!".to_string(),
+        vec![Key::new("bogons").i64(100)],
+    );
+
+    println!("Tracer created with ID: {}", span.span_context().trace_id());
+
+    let p_span_id = span.span_context().span_id();
+    let parent_cx = Context::current_with_span(span);
+
+    let mut c_span = tracer.start_with_context("API Call-b3single", &parent_cx);
+    let _ = outgoing_request(c_span.span_context().span_id(), p_span_id, c_span.span_context().trace_id()).await;
+    c_span.set_attribute(KeyValue::new("header-type", "b3 single"));
+    c_span.add_event(
+        "made an API call to laravel".to_string(),
+        vec![Key::new("bogons").i64(100)],
+    );
+    c_span.end();
+
+    let mut a_span = tracer.start_with_context("API Call- b3multi", &parent_cx);
+    let _ = outgoing_request_multi(a_span.span_context().span_id(), p_span_id, a_span.span_context().trace_id()).await;
+    a_span.set_attribute(KeyValue::new("header-type", "b3 multi"));
+    a_span.add_event(
+        "made an API call to laravel".to_string(),
+        vec![Key::new("bogons").i64(100)],
+    );
+    a_span.end();
+
+    drop(parent_cx);
+    drop(main_cx);
+    global::shutdown_tracer_provider();
+    Ok(())
+}

--- a/opentelemetry-sdk/src/trace/config.rs
+++ b/opentelemetry-sdk/src/trace/config.rs
@@ -28,6 +28,9 @@ pub struct Config {
 
     /// Contains attributes representing an entity that produces telemetry.
     pub resource: Cow<'static, Resource>,
+
+    /// Set this to true if sending tracces to receiver that needs 64 bit TraceIds.
+    pub backward_compatible: Option<bool>,
 }
 
 impl Config {
@@ -84,6 +87,12 @@ impl Config {
         self.resource = Cow::Owned(resource);
         self
     }
+
+    /// Setting this to true will generate 128 bit TraceId with high 64 bits as zeros
+    pub fn with_backward_compatible(mut self, backward_compatible: bool) -> Self {
+        self.backward_compatible = Some(backward_compatible);
+        self
+    }
 }
 
 impl Default for Config {
@@ -94,6 +103,7 @@ impl Default for Config {
             id_generator: Box::<RandomIdGenerator>::default(),
             span_limits: SpanLimits::default(),
             resource: Cow::Owned(Resource::default()),
+            backward_compatible: Some(false)
         };
 
         if let Some(max_attributes_per_span) = env::var("OTEL_SPAN_ATTRIBUTE_COUNT_LIMIT")

--- a/opentelemetry-sdk/src/trace/id_generator/aws.rs
+++ b/opentelemetry-sdk/src/trace/id_generator/aws.rs
@@ -40,9 +40,9 @@ pub struct XrayIdGenerator {
 
 impl IdGenerator for XrayIdGenerator {
     /// Generates a new `TraceId` that can be converted to an X-Ray Trace ID
-    fn new_trace_id(&self) -> TraceId {
+    fn new_trace_id(&self, _backward_compatible: Option<bool>) -> TraceId {
         let mut default_trace_id: String =
-            format!("{:024x}", self.sdk_default_generator.new_trace_id());
+            format!("{:024x}", self.sdk_default_generator.new_trace_id(None));
 
         default_trace_id.truncate(24);
 

--- a/opentelemetry-sdk/src/trace/id_generator/mod.rs
+++ b/opentelemetry-sdk/src/trace/id_generator/mod.rs
@@ -9,7 +9,7 @@ use std::fmt;
 /// Interface for generating IDs
 pub trait IdGenerator: Send + Sync + fmt::Debug {
     /// Generate a new `TraceId`
-    fn new_trace_id(&self) -> TraceId;
+    fn new_trace_id(&self, backward_compatible: Option<bool>) -> TraceId;
 
     /// Generate a new `SpanId`
     fn new_span_id(&self) -> SpanId;
@@ -24,7 +24,12 @@ pub struct RandomIdGenerator {
 }
 
 impl IdGenerator for RandomIdGenerator {
-    fn new_trace_id(&self) -> TraceId {
+    fn new_trace_id(&self, backward_compatible: Option<bool>) -> TraceId {
+        let backward_compatible_val: bool = backward_compatible == Some(true);
+        if backward_compatible_val {
+            let span_id_to_convert: SpanId = CURRENT_RNG.with(|rng| SpanId::from(rng.borrow_mut().gen::<[u8; 8]>()));
+            return TraceId::from_hex(&span_id_to_convert.to_string()).unwrap();
+        }
         CURRENT_RNG.with(|rng| TraceId::from(rng.borrow_mut().gen::<[u8; 16]>()))
     }
 

--- a/opentelemetry-sdk/src/trace/tracer.rs
+++ b/opentelemetry-sdk/src/trace/tracer.rs
@@ -168,7 +168,7 @@ impl opentelemetry_api::trace::Tracer for Tracer {
         } else {
             trace_id = builder
                 .trace_id
-                .unwrap_or_else(|| config.id_generator.new_trace_id());
+                .unwrap_or_else(|| config.id_generator.new_trace_id(config.backward_compatible));
         };
 
         // In order to accomodate use cases like `tracing-opentelemetry` we there is the ability


### PR DESCRIPTION
Added support for 64 bit trace Ids. 
Refer Example [here]( https://github.com/splunk/opentelemetry-rust-v0.19.0/tree/main/examples/backward-compatibility).